### PR TITLE
Add Camelot admin services dashboard links section

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,43 @@ me.say_hi()
 
 ---
 
+## 🏰 Camelot Dashboard: All Services (Admin)
+
+<div align="center">
+  <table>
+    <tr>
+      <th>Service</th>
+      <th>Admin Link</th>
+    </tr>
+    <tr>
+      <td>Railway</td>
+      <td><a href="https://railway.app/dashboard">Open Railway Dashboard</a></td>
+    </tr>
+    <tr>
+      <td>Vercel</td>
+      <td><a href="https://vercel.com/dashboard">Open Vercel Dashboard</a></td>
+    </tr>
+    <tr>
+      <td>Supabase</td>
+      <td><a href="https://supabase.com/dashboard/projects">Open Supabase Dashboard</a></td>
+    </tr>
+    <tr>
+      <td>GitHub</td>
+      <td><a href="https://github.com/dashboard">Open GitHub Dashboard</a></td>
+    </tr>
+    <tr>
+      <td>Polygon</td>
+      <td><a href="https://polygonscan.com/">Open Polygon Explorer</a></td>
+    </tr>
+    <tr>
+      <td><b>All Services</b></td>
+      <td><a href="https://github.com/MAKaminski">Open Services Hub (GitHub)</a></td>
+    </tr>
+  </table>
+</div>
+
+---
+
 ## 🛠️ Tech Arsenal
 
 <details open>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a new `Camelot Dashboard: All Services (Admin)` section to `README.md`
- include a centered tabular box with admin-side links for Railway, Vercel, Supabase, GitHub, Polygon, and an "All Services" row

## Testing
- verified the section heading and all requested service links exist in `README.md` via ripgrep
- confirmed clean working tree after commit and push
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bfa2a0c1-6e70-4d2b-8899-0f71061b090d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bfa2a0c1-6e70-4d2b-8899-0f71061b090d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

