### PR TITLE
fix(ci): Make profile stats refresh resilient to sustained 503s

### DIFF
--- a/.github/workflows/refresh-stats.yml
+++ b/.github/workflows/refresh-stats.yml
@@ -4,6 +4,9 @@
 #
 # Schedule: every 5 minutes (GitHub's minimum; may hit external API rate limits)
 # Manual: workflow_dispatch
+#
+# Upstream SVG hosts (Vercel/Heroku) often return 503 under load; curl retries
+# reduce spurious workflow failures.
 
 name: Refresh Profile Stats
 
@@ -29,42 +32,26 @@ jobs:
       - name: Create assets directory
         run: mkdir -p assets/stats
 
-      - name: Fetch GitHub Stats (all commits, private-aware)
+      - name: Fetch profile stat SVGs
         run: |
-          curl -fsSL "https://github-readme-stats.vercel.app/api?username=MAKaminski&show_icons=true&theme=radical&include_all_commits=true&count_private=true&rank_icon=github" -o assets/stats/github-stats.svg
-
-      - name: Fetch GitHub Streak
-        run: |
-          curl -fsSL "https://github-readme-streak-stats.herokuapp.com/?user=MAKaminski&theme=radical&border_radius=10" -o assets/stats/github-streak.svg
-
-      - name: Fetch GitHub Profile Summary
-        run: |
-          curl -fsSL "https://github-profile-summary-cards.vercel.app/api/cards/profile-details?username=MAKaminski&theme=radical" -o assets/stats/profile-details.svg
-
-      - name: Fetch Commits by Hour
-        run: |
-          curl -fsSL "https://github-profile-summary-cards.vercel.app/api/cards/productive-time?username=MAKaminski&theme=radical" -o assets/stats/productive-time.svg
-
-      - name: Fetch Repos per Language
-        run: |
-          curl -fsSL "https://github-profile-summary-cards.vercel.app/api/cards/repos-per-language?username=MAKaminski&theme=radical" -o assets/stats/repos-per-language.svg
-
-      - name: Fetch Top Languages
-        run: |
-          curl -fsSL "https://github-readme-stats.vercel.app/api/top-langs/?username=MAKaminski&layout=compact&theme=radical&border_radius=10&langs_count=8" -o assets/stats/top-langs.svg
-
-      - name: Fetch Most Used Languages
-        run: |
-          curl -fsSL "https://github-profile-summary-cards.vercel.app/api/cards/most-commit-language?username=MAKaminski&theme=radical" -o assets/stats/most-commit-language.svg
-
-      - name: Fetch Contribution Activity Graph
-        run: |
-          curl -fsSL "https://github-readme-activity-graph.vercel.app/graph?username=MAKaminski&theme=react-dark&hide_border=true" -o assets/stats/activity-graph.svg
+          set -euo pipefail
+          # Transient 5xx from third-party hosts; curl --retry handles backoff.
+          CURL="curl -fsSL --connect-timeout 25 --max-time 120 --retry 8 --retry-delay 5 --retry-max-time 300"
+          $CURL "https://github-readme-stats.vercel.app/api?username=MAKaminski&show_icons=true&theme=radical&include_all_commits=true&count_private=true&rank_icon=github" -o assets/stats/github-stats.svg
+          $CURL "https://github-readme-streak-stats.herokuapp.com/?user=MAKaminski&theme=radical&border_radius=10" -o assets/stats/github-streak.svg
+          $CURL "https://github-profile-summary-cards.vercel.app/api/cards/profile-details?username=MAKaminski&theme=radical" -o assets/stats/profile-details.svg
+          $CURL "https://github-profile-summary-cards.vercel.app/api/cards/productive-time?username=MAKaminski&theme=radical" -o assets/stats/productive-time.svg
+          $CURL "https://github-profile-summary-cards.vercel.app/api/cards/repos-per-language?username=MAKaminski&theme=radical" -o assets/stats/repos-per-language.svg
+          $CURL "https://github-readme-stats.vercel.app/api/top-langs/?username=MAKaminski&layout=compact&theme=radical&border_radius=10&langs_count=8" -o assets/stats/top-langs.svg
+          $CURL "https://github-profile-summary-cards.vercel.app/api/cards/most-commit-language?username=MAKaminski&theme=radical" -o assets/stats/most-commit-language.svg
+          $CURL "https://github-readme-activity-graph.vercel.app/graph?username=MAKaminski&theme=react-dark&hide_border=true" -o assets/stats/activity-graph.svg
 
       - name: Fetch Trophies
         continue-on-error: true
         run: |
-          curl -fsSL "https://github-profile-trophy.vercel.app/?username=MAKaminski&theme=radical&row=2&column=3&title=Followers,Stars,Commits,Repositories,PullRequest,MultiLanguage" -o assets/stats/trophies.svg
+          curl -fsSL --connect-timeout 25 --max-time 120 --retry 8 --retry-delay 5 --retry-max-time 300 \
+            "https://github-profile-trophy.vercel.app/?username=MAKaminski&theme=radical&row=2&column=3&title=Followers,Stars,Commits,Repositories,PullRequest,MultiLanguage" \
+            -o assets/stats/trophies.svg
 
       - name: Commit and push if changed
         run: |

--- a/.github/workflows/refresh-stats.yml
+++ b/.github/workflows/refresh-stats.yml
@@ -5,8 +5,9 @@
 # Schedule: every 5 minutes (GitHub's minimum; may hit external API rate limits)
 # Manual: workflow_dispatch
 #
-# Upstream SVG hosts (Vercel/Heroku) often return 503 under load; curl retries
-# reduce spurious workflow failures.
+# Third-party SVG endpoints can return 503 for extended periods. curl's built-in
+# --retry is not always enough; we retry in a shell loop and keep the last
+# committed SVG on disk when a fetch never succeeds so the job stays green.
 
 name: Refresh Profile Stats
 
@@ -34,24 +35,48 @@ jobs:
 
       - name: Fetch profile stat SVGs
         run: |
-          set -euo pipefail
-          # Transient 5xx from third-party hosts; curl --retry handles backoff.
-          CURL="curl -fsSL --connect-timeout 25 --max-time 120 --retry 8 --retry-delay 5 --retry-max-time 300"
-          $CURL "https://github-readme-stats.vercel.app/api?username=MAKaminski&show_icons=true&theme=radical&include_all_commits=true&count_private=true&rank_icon=github" -o assets/stats/github-stats.svg
-          $CURL "https://github-readme-streak-stats.herokuapp.com/?user=MAKaminski&theme=radical&border_radius=10" -o assets/stats/github-streak.svg
-          $CURL "https://github-profile-summary-cards.vercel.app/api/cards/profile-details?username=MAKaminski&theme=radical" -o assets/stats/profile-details.svg
-          $CURL "https://github-profile-summary-cards.vercel.app/api/cards/productive-time?username=MAKaminski&theme=radical" -o assets/stats/productive-time.svg
-          $CURL "https://github-profile-summary-cards.vercel.app/api/cards/repos-per-language?username=MAKaminski&theme=radical" -o assets/stats/repos-per-language.svg
-          $CURL "https://github-readme-stats.vercel.app/api/top-langs/?username=MAKaminski&layout=compact&theme=radical&border_radius=10&langs_count=8" -o assets/stats/top-langs.svg
-          $CURL "https://github-profile-summary-cards.vercel.app/api/cards/most-commit-language?username=MAKaminski&theme=radical" -o assets/stats/most-commit-language.svg
-          $CURL "https://github-readme-activity-graph.vercel.app/graph?username=MAKaminski&theme=react-dark&hide_border=true" -o assets/stats/activity-graph.svg
+          set -uo pipefail
+          # Per-URL retries; on total failure leave the file from checkout unchanged.
+          fetch_svg() {
+            local url="$1"
+            local dest="$2"
+            local attempts="${3:-10}"
+            local delay="${4:-15}"
+            local tmp i
+            tmp="${dest}.part.$$"
+            i=1
+            while [ "$i" -le "$attempts" ]; do
+              if curl -fsSL --connect-timeout 25 --max-time 120 \
+                --retry 3 --retry-delay 3 --retry-max-time 60 \
+                "$url" -o "$tmp" 2>/dev/null; then
+                mv -f "$tmp" "$dest"
+                echo "OK: $dest"
+                return 0
+              fi
+              rm -f "$tmp"
+              if [ "$i" -lt "$attempts" ]; then
+                echo "Retry $i/$attempts for $(basename "$dest") (sleep ${delay}s)..."
+                sleep "$delay"
+              fi
+              i=$((i + 1))
+            done
+            if [ -f "$dest" ]; then
+              echo "::warning::Upstream unavailable; keeping committed file: $dest"
+            else
+              echo "::warning::No prior file and fetch failed: $dest (URL omitted from README until next success)"
+            fi
+            return 0
+          }
 
-      - name: Fetch Trophies
-        continue-on-error: true
-        run: |
-          curl -fsSL --connect-timeout 25 --max-time 120 --retry 8 --retry-delay 5 --retry-max-time 300 \
-            "https://github-profile-trophy.vercel.app/?username=MAKaminski&theme=radical&row=2&column=3&title=Followers,Stars,Commits,Repositories,PullRequest,MultiLanguage" \
-            -o assets/stats/trophies.svg
+          fetch_svg "https://github-readme-stats.vercel.app/api?username=MAKaminski&show_icons=true&theme=radical&include_all_commits=true&count_private=true&rank_icon=github" "assets/stats/github-stats.svg"
+          fetch_svg "https://github-readme-streak-stats.herokuapp.com/?user=MAKaminski&theme=radical&border_radius=10" "assets/stats/github-streak.svg"
+          fetch_svg "https://github-profile-summary-cards.vercel.app/api/cards/profile-details?username=MAKaminski&theme=radical" "assets/stats/profile-details.svg"
+          fetch_svg "https://github-profile-summary-cards.vercel.app/api/cards/productive-time?username=MAKaminski&theme=radical" "assets/stats/productive-time.svg"
+          fetch_svg "https://github-profile-summary-cards.vercel.app/api/cards/repos-per-language?username=MAKaminski&theme=radical" "assets/stats/repos-per-language.svg"
+          fetch_svg "https://github-readme-stats.vercel.app/api/top-langs/?username=MAKaminski&layout=compact&theme=radical&border_radius=10&langs_count=8" "assets/stats/top-langs.svg"
+          fetch_svg "https://github-profile-summary-cards.vercel.app/api/cards/most-commit-language?username=MAKaminski&theme=radical" "assets/stats/most-commit-language.svg"
+          fetch_svg "https://github-readme-activity-graph.vercel.app/graph?username=MAKaminski&theme=react-dark&hide_border=true" "assets/stats/activity-graph.svg"
+          fetch_svg "https://github-profile-trophy.vercel.app/?username=MAKaminski&theme=radical&row=2&column=3&title=Followers,Stars,Commits,Repositories,PullRequest,MultiLanguage" "assets/stats/trophies.svg"
 
       - name: Commit and push if changed
         run: |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Refresh Profile Stats** was still failing because `github-readme-stats.vercel.app` (and related hosts) can return **HTTP 503** on every attempt—`curl --retry` exhausts and the step exits 22.

## Changes

- **Per-URL shell retries** (10 rounds, 15s between rounds) plus inner `curl --retry` for short blips.
- **Download to a temp file, then `mv`** so failed responses never overwrite good SVGs.
- If all attempts fail but the repo already has that asset from checkout, **keep the last committed file** and log a **warning**; the **workflow succeeds** so CI stays green during upstream outages.
- **Trophies** use the same helper (single fetch step).

Merge to `main` to stop repeated red runs; SVGs refresh automatically when third-party APIs recover.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df3d8919-8732-4b51-848f-ace31dce604c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df3d8919-8732-4b51-848f-ace31dce604c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

